### PR TITLE
Use the rankdir setting instead of unflatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ and then process it using `unflatten`:
 unflatten -f -l 4 -c 16 graph.dot  | dot | gvpack -array_t6 | neato -s -n2 -Tpng -o graph.png
 ```
 
+For a slightly cleaner layout (that preserves the ranks), or if your system doesn't have `unflatten`, you can use `sed` to insert `rankdir=LR;` into the dot file before processing it:
+```bash
+sed -i 's/digraph{/digraph{ rankdir=LR;/g' graph.dot | dot -o graph.png -Tpng
+```
+
 Notes:
 ======
 Based on: [draw-chart.py](https://developer.atlassian.com/download/attachments/4227078/draw-chart.py) and [Atlassian JIRA development documentation](https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Version+2+Tutorial#JIRARESTAPIVersion2Tutorial-Example#1:GraphingImageLinks), which seemingly was no longer compatible with JIRA REST API Version 2.


### PR DESCRIPTION
For left-to-right layout, instead of using `unflatten`, show how to insert the rankdir setting into the dot file before processing. This setting preserves the ranks of each level.