### PR TITLE
Skip issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ $ python jira-dependency-graph.py --user=your-jira-username --password=your-jira
 
 In order to only specify issues with a certain prefix pass in `--issue-include <XXX>` and all tickets will be checked that they match the prefix `XXX`.
 
+### Excluding Issues
+
+By passing in `--issue-exclude`, or `-xi` the system will explicitly ignore the ticket. It can be repeated multiple times, e.g. `-xi MYPR-456 -x MYPR-999` to ignore both issues. 
+Use it as a last-resort only, when other means of exclusion do not suit your case, e.g. to omit a part of the graph for better readability.
+
 ### Authentication
 
 It is possible to either use the username/password combination or to login via the browser passing in `--cookie <JSESSIONID>`. This logins via the browser and is useful in scenarios where Kerberos authentication is required.

--- a/jira-dependency-graph.py
+++ b/jira-dependency-graph.py
@@ -124,7 +124,7 @@ def build_graph_data(start_issue_key, jira, excludes, show_directions, direction
         if includes not in linked_issue_key:
             return
 
-        if link_type in excludes:
+        if link_type.strip() in excludes:
             return linked_issue_key, None
 
         arrow = ' => ' if direction == 'outward' else ' <= '

--- a/jira-dependency-graph.py
+++ b/jira-dependency-graph.py
@@ -107,6 +107,11 @@ def build_graph_data(start_issue_key, jira, excludes, show_directions, direction
 
         linked_issue = link[direction + 'Issue']
         linked_issue_key = get_key(linked_issue)
+
+        if skip_issue(linked_issue_key, linked_issue['fields']):
+            # logging present in skip_issue(), hence bare return here
+            return
+
         if linked_issue_key in issue_excludes:
             log('Skipping ' + linked_issue_key + ' - explicitly excluded')
             return
@@ -153,12 +158,7 @@ def build_graph_data(start_issue_key, jira, excludes, show_directions, direction
         fields = issue['fields']
         seen.append(issue_key)
 
-        if ignore_closed and (fields['status']['name'] in 'Closed'):
-            log('Skipping ' + issue_key + ' - it is Closed')
-            return graph
-
-        if not traverse and ((project_prefix + '-') not in issue_key):
-            log('Skipping ' + issue_key + ' - not traversing to a different project')
+        if skip_issue(issue_key, fields):
             return graph
 
         graph.append(create_node_text(issue_key, fields, islink=False))
@@ -169,11 +169,12 @@ def build_graph_data(start_issue_key, jira, excludes, show_directions, direction
                 for subtask in issues:
                     subtask_key = get_key(subtask)
                     log(subtask_key + ' => references epic => ' + issue_key)
-                    node = '{}->{}[color=orange]'.format(
-                        create_node_text(issue_key, fields),
-                        create_node_text(subtask_key, subtask['fields']))
-                    graph.append(node)
-                    children.append(subtask_key)
+                    if not skip_issue(subtask_key, subtask['fields']):
+                        node = '{}->{}[color=orange]'.format(
+                            create_node_text(issue_key, fields),
+                            create_node_text(subtask_key, subtask['fields']))
+                        graph.append(node)
+                        children.append(subtask_key)
             if fields.has_key('subtasks') and not ignore_subtasks:
                 for subtask in fields['subtasks']:
                     subtask_key = get_key(subtask)
@@ -196,6 +197,15 @@ def build_graph_data(start_issue_key, jira, excludes, show_directions, direction
         for child in (x for x in children if x not in seen):
             walk(child, graph)
         return graph
+
+    def skip_issue(issue_key, fields):
+        if ignore_closed and (fields['status']['name'] in 'Closed'):
+            log('Skipping ' + issue_key + ' - it is Closed')
+            return True
+        if not traverse and ((project_prefix + '-') not in issue_key):
+            log('Skipping ' + issue_key + ' - not traversing to a different project')
+            return True
+        return False
 
     project_prefix = start_issue_key.split('-', 1)[0]
     return walk(start_issue_key, [])


### PR DESCRIPTION
Correct the logic around skipping issues, on e.g. --dont-traverse
 
Previously when --dont-traverse was in effect, some other project
ticket could still make it into the diagram. Hence the logic has
been extracted to a skip_issue method and used in 2 additional
places; f.ex. when processing issues "under" an epic.
