### PR TITLE
Add option to not use authentication at all

### DIFF
--- a/jira-dependency-graph.py
+++ b/jira-dependency-graph.py
@@ -230,6 +230,7 @@ def parse_args():
     parser.add_argument('-u', '--user', dest='user', default=None, help='Username to access JIRA')
     parser.add_argument('-p', '--password', dest='password', default=None, help='Password to access JIRA')
     parser.add_argument('-c', '--cookie', dest='cookie', default=None, help='JSESSIONID session cookie value')
+    parser.add_argument('-N', '--no-auth', dest='no_auth', action='store_true', default=False, help='Use no authentication')
     parser.add_argument('-j', '--jira', dest='jira_url', default='http://jira.example.com', help='JIRA Base URL (with protocol)')
     parser.add_argument('-f', '--file', dest='image_file', default='issue_graph.png', help='Filename to write image to')
     parser.add_argument('-l', '--local', action='store_true', default=False, help='Render graphviz code to stdout')
@@ -263,6 +264,9 @@ def main():
     if options.cookie is not None:
         # Log in with browser and use --cookie=ABCDEF012345 commandline argument
         auth = options.cookie
+    elif options.no_auth is True:
+        # Don't use authentication when it's not needed
+        auth = None
     else:
         # Basic Auth is usually easier for scripts like this to deal with than Cookies.
         user = options.user if options.user is not None \


### PR DESCRIPTION
Jira deployed behind a firewall may be accessible read-only without
authentication, better not to handle passwords when unnecessary.